### PR TITLE
Fix longevity test runs (nginxinc#2065)

### DIFF
--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -18,6 +18,8 @@ permissions:
 jobs:
   release:
     runs-on: ubuntu-22.04
+    permissions:
+      contents: write
     steps:
       - name: Branch
         id: branch

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -100,11 +100,11 @@ nfr-test: ## Run the NFR tests on a GCP VM
 	NFR=true bash scripts/run-tests-gcp-vm.sh
 
 .PHONY: start-longevity-test
-start-longevity-test: START_LONGEVITY=true
+start-longevity-test: export START_LONGEVITY=true
 start-longevity-test: nfr-test ## Start the longevity test to run for 4 days in GKE
 
 .PHONY: stop-longevity-test
-stop-longevity-test: STOP_LONGEVITY=true
+stop-longevity-test: export STOP_LONGEVITY=true
 stop-longevity-test: nfr-test ## Stop the longevity test and collects results
 
 .PHONY: .vm-nfr-test


### PR DESCRIPTION
Problem:
Running longevity test mistakenly runs all other NFRs
make start-longevity-test and make stop-longevity-test mistakenly
executes all NFRs. Only longevity test must run.

Solution:
Problem was introduced in 18671fb
Ensure the env variables are exported so that they are passed to nfr-test target.

Testing:
- Ran make start-longevity-test and make stop-longevity-test successfully.

CLOSES - nginxinc#2064### Proposed changes

Write a clear and concise description that helps reviewers understand the purpose and impact of your changes. Use the
following format:

Problem: Give a brief overview of the problem or feature being addressed.

Solution: Explain the approach you took to implement the solution, highlighting any significant design decisions or
considerations.

Testing: Describe any testing that you did.

Please focus on (optional): If you any specific areas where you would like reviewers to focus their attention or provide
specific feedback, add them here.

Closes #ISSUE

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [ ] I have read the [CONTRIBUTING](https://github.com/nginxinc/nginx-gateway-fabric/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [ ] I have rebased my branch onto main
- [ ] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork

### Release notes

If this PR introduces a change that affects users and needs to be mentioned in the [release notes](../blob/main/CHANGELOG.md),
please add a brief note that summarizes the change.

<!-- If this PR does not require a release note, you can just write NONE in the release-note block below. -->

```release-note

```
